### PR TITLE
[Exercises 6.5] Add test for the email downcasing and more

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ActiveRecord::Base
     presence: true,
     length: { maximum: 50}
 
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
   validates :email,
    presence: true,
    length: { maximum: 255 },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,5 +16,5 @@ class User < ActiveRecord::Base
     presence: true,
     length: { minimum: 6 }
 
-  before_save { self.email = email.downcase }
+  before_save { email.downcase! }
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -44,7 +44,7 @@ class UserTest < ActiveSupport::TestCase
 
   test "email validation should reject invalid addresses" do
     invalid_addresses = %w[user@example,com user_at_foo.org user.name@example.
-                           foo@bar_baz.com foo@bar+baz.com]
+                           foo@bar_baz.com foo@bar+baz.com foo@bar..com]
     invalid_addresses.each do |invalid_address|
       @user.email = invalid_address
       assert_not @user.valid?, "#{invalid_address.inspect} should be invalid"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -58,6 +58,13 @@ class UserTest < ActiveSupport::TestCase
     assert_not duplicate_user.valid?
   end
 
+  test "email addresses should be saved as lower-case" do
+    mixed_case_email = "Foo@ExAMPle.CoM"
+    @user.email = mixed_case_email
+    @user.save
+    assert_equal mixed_case_email.downcase, @user.reload.email
+  end
+
   test "password should be present (nonblank)" do
     @user.password = @user.password_confirmation = " " * 6
     assert_not @user.valid?


### PR DESCRIPTION
## TODO

- [x] 1.  Add a test for the email downcasing from Listing 6.31, as shown in Listing 6.41
  - [x] Comment out the before_save line to get to `red`
  - [x] Uncomment it to get to `green`
- [x] 2. Verify that the `before_save` callback can be written using the “bang” method  to modify the email attribute directly, as shown in Listing 6.42
- [x] 3. Improve email regex
  - [x] Add this address to the list of invalid addresses in Listing 6.19 to get a failing test
  - [x] Use the more complicated regex shown in Listing 6.43 to get the test to pass

## Completion Conditions

- [x] Pasted TravisCI test
- [x] Get `OK` or `LGTM` from one of rjk