### PR TITLE
[Exercise 7.7] Change 'gravatar_for' helper and more

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,7 +1,8 @@
 module UsersHelper
-  def gravatar_for(user)
+  def gravatar_for(user, options = { size: 80 })
     gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
-    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}"
+    size = options[:size]
+    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
     image_tag(gravatar_url, alt: user.name, class: "gravatar")
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= render 'layouts/header' %>
     <div class="container">
       <% flash.each do |message_type, message| %>
-        <div class="alert alert-<%= message_type %>"><%= message %></div>
+        <%= content_tag(:div, message, class: "alert alert-#{message_type}") %>
       <% end %>
       <%= yield %>
       <%= render 'layouts/footer' %>

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -11,6 +11,8 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
                 password_confirmation: "password" }
     end
     assert_template 'users/show'
+
+    assert_not flash.empty?
   end
 
   test "invalid signup information" do
@@ -23,7 +25,7 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
                 password_confirmation: "bar" }
     end
     assert_template 'users/new'
-    
+
     assert_select 'div#error_explanation'
     assert_select 'div.alert.alert-danger'
   end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -23,5 +23,8 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
                 password_confirmation: "bar" }
     end
     assert_template 'users/new'
+    
+    assert_select 'div#error_explanation'
+    assert_select 'div.alert.alert-danger'
   end
 end


### PR DESCRIPTION
## TODO

- [x] 1. Change `gravatar_for` helper defined in Section 7.1.4 to take an optional size parameter
- [x] 2. Write a test for the error messages implemented in Listing 7.18
  - [x] Complete by replacing `<CSS id/class~>`
- [x] 3. Write a test for the flash implemented in Section 7.4.2
  - [x] Complete by replacing `FILL_IN`
- [x] 4. Verify by running the test suite that the cleaner code in Listing 7.34
  -  [x]  Pass by green to run the test 'user_signup_test.rb'

## Completion Conditions

- [x] Passed by all green TravisCI test
- [x] Get `OK` or `LGTM` from one of rjk