### PR TITLE
[Exercise 9.6] Add a test for friendly forwarding and more

### DIFF
--- a/app/views/users/_fields.html.erb
+++ b/app/views/users/_fields.html.erb
@@ -1,0 +1,13 @@
+<%= render 'shared/error_messages' %>
+
+<%= f.label :name %>
+<%= f.text_field :name, class: 'form-control' %>
+
+<%= f.label :email %>
+<%= f.email_field :email, class: 'form-control' %>
+
+<%= f.label :password %>
+<%= f.password_field :password, class: 'form-control' %>
+
+<%= f.label :password_confirmation, "Confirmation" %>
+<%= f.password_field :password_confirmation, class: 'form-control' %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -4,20 +4,7 @@
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <%= form_for(@user) do |f| %>
-      <%= render 'shared/error_messages' %>
-
-      <%= f.label :name %>
-      <%= f.text_field :name, class: 'form-control' %>
-
-      <%= f.label :email %>
-      <%= f.email_field :email, class: 'form-control' %>
-
-      <%= f.label :password %>
-      <%= f.password_field :password, class: 'form-control' %>
-
-      <%= f.label :password_confirmation, "Confirmation" %>
-      <%= f.password_field :password_confirmation, class: 'form-control' %>
-
+      <%= render 'fields', f: f %>
       <%= f.submit "Save changes", class: "btn btn-primary" %>
     <% end %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -4,20 +4,7 @@
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <%= form_for(@user) do |f| %>
-      <%= render 'shared/error_messages' %>
-
-      <%= f.label :name %>
-      <%= f.text_field :name, class: 'form-control' %>
-
-      <%= f.label :email %>
-      <%= f.email_field :email, class: 'form-control' %>
-
-      <%= f.label :password %>
-      <%= f.password_field :password, class: 'form-control' %>
-
-      <%= f.label :password_confirmation, "Confirmation" %>
-      <%= f.password_field :password_confirmation, class: 'form-control' %>
-
+      <%= render 'fields', f: f %>
       <%= f.submit "Create my account", class: "btn btn-primary" %>
     <% end %>
   </div>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -47,7 +47,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_not @other_user.admin?
     patch :update, id: @other_user, user: { password:              "password",
                                             password_confirmation: "password",
-                                            admin: true }
+                                            admin: "1" }
     assert_not @other_user.reload.admin?
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -42,6 +42,15 @@ class UsersControllerTest < ActionController::TestCase
     assert_redirected_to root_url
   end
 
+  test "should not allow the admin attribute to be edited via the web" do
+    log_in_as(@other_user)
+    assert_not @other_user.admin?
+    patch :update, id: @other_user, user: { password:              "password",
+                                            password_confirmation: "password",
+                                            admin: true }
+    assert_not @other_user.reload.admin?
+  end
+
   test "should redirect destroy when not logged in" do
     assert_no_difference 'User.count' do
       delete :destroy, id: @user

--- a/test/integration/site_layout_test.rb
+++ b/test/integration/site_layout_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class SiteLayoutTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:michael)
+  end
+
   test "layout links" do
     get root_path
     assert_template 'static_pages/home'
@@ -8,7 +12,14 @@ class SiteLayoutTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", help_path
     assert_select "a[href=?]", about_path
     assert_select "a[href=?]", contact_path
+    assert_select "a[href=?]", login_path
     get signup_path
     assert_select "title", full_title("Sign up")
+    log_in_as(@user)
+    get root_path
+    assert_select "a[href=?]", users_path
+    assert_select "a[href=?]", user_path(@user)
+    assert_select "a[href=?]", edit_user_path(@user)
+    assert_select "a[href=?]", logout_path
   end
 end

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -7,6 +7,7 @@ class UsersEditTest < ActionDispatch::IntegrationTest
 
   test "successful edit with friendly forwarding" do
     get edit_user_path(@user)
+    assert_equal edit_user_url(@user), session[:forwarding_url]
     log_in_as(@user)
     assert_redirected_to edit_user_path(@user)
     name  = "Foo Bar"


### PR DESCRIPTION
## TODO

- [x] 1. Add to the test in Listing 9.26 by checking for the right value of `session[:forwarding_url]`
- [x] 2. Add to the test in Listing 5.25 using the `log_in_as` helper
- [x] 3. Verify that the admin attribute isn’t editable by issuing a PATCH request directly to the update method as shown in Listing 9.59
  - [x] Replace 'FILL_IN' in Listing 9.59
  - [x] Verify the test is covering the right thing by running the test
  - [x] Verify the test is RED by adding `admin` to the list of permitted parameters in `user_params`
- [x] 4. Remove the duplicated form code by refactoring the `new.html.erb` and `edit.html.erb` views to use the partial in Listing 9.60

## Completion Conditions

- [x] Passed by all green TravisCI test
- [x] Get `OK` or `LGTM` from __two__ of rjk