### PR TITLE
[Exercise 10.5] Add an integration test for the expired password reset and more

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,11 +4,13 @@ class UsersController < ApplicationController
   before_action :admin_user,     only: :destroy
 
   def index
-    @users = User.paginate(page: params[:page])
+    # @users = User.paginate(page: params[:page])
+    @users = User.where(activated: true).paginate(page: params[:page])
   end
 
   def show
     @user = User.find(params[:id])
+    redirect_to root_url and return unless @user.activated?
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,13 +55,13 @@ class User < ActiveRecord::Base
 
   # Activates an account.
   def activate
-    update_columns(activated: true, activated_at: Time.zone.now)
+    update_attributes({activated: true, activated_at: Time.zone.now})
   end
 
   # Sets the password reset attributes.
   def create_reset_digest
     self.reset_token = User.new_token
-    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
+    update_attributes({reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now})
   end
 
   # Sends activation email.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,13 +55,13 @@ class User < ActiveRecord::Base
 
   # Activates an account.
   def activate
-    update_attributes({activated: true, activated_at: Time.zone.now})
+    update_columns(activated: true, activated_at: Time.zone.now)
   end
 
   # Sets the password reset attributes.
   def create_reset_digest
     self.reset_token = User.new_token
-    update_attributes({reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now})
+    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
   end
 
   # Sends activation email.

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -58,4 +58,19 @@ class PasswordResetsTest < ActionDispatch::IntegrationTest
     assert_not flash.empty?
     assert_redirected_to user
   end
+
+  test "expired token" do
+    get new_password_reset_path
+    post password_resets_path, password_reset: { email: @user.email }
+
+    @user = assigns(:user)
+    @user.update_attribute(:reset_sent_at, 3.hours.ago)
+    patch password_reset_path(@user.reset_token),
+          email: @user.email,
+          user: { password:              "foobar",
+                  password_confirmation: "foobar" }
+    assert_response :redirect
+    follow_redirect!
+    assert_match /expired/i, response.body
+  end
 end

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -28,4 +28,12 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     get users_path
     assert_select 'a', text: 'delete', count: 0
   end
+
+  test "index including only activated users" do
+    @non_admin.toggle!(:activated)
+    log_in_as(@admin)
+    get users_path
+    assert_select 'a[href=?]', user_path(@admin), text: @admin.name
+    assert_select 'a[href=?]', user_path(@non_admin), text: @non_admin.name, count: 0
+  end
 end

--- a/test/integration/users_show_test_test.rb
+++ b/test/integration/users_show_test_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class UsersShowTestTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:michael)
+  end
+
+  test "show activated user" do
+    get user_path(@user)
+    assert_template 'users/show'
+    assert_select ".user_info", @user.name
+  end
+
+  test "show user unactivated" do
+    @user.toggle!(:activated)
+    get user_path(@user)
+    assert_redirected_to root_url
+  end
+end


### PR DESCRIPTION
## Exercises
https://www.railstutorial.org/book/account_activation_password_reset#sec-activation_resets_exercises

## TODO

- [x] 1. Add an integration test for the expired password reset to check that the response body includes the word `expired`
- [x] 2. Improve `index` and `show` action by filling in the template shown in Listing 10.58
  - [x] Replace `FILL_IN` in Listing 10.58
  - [x] Extra credit: Add integration tests for both `/users` and `/users/:id`
- [x] 3. Replace each pair of `update_attribute` calls with a single call to `update_columns` by filling in the template shown in Listing 10.59
  - [x] Replace `FILL_IN` in Listing 10.59
  - [x] Verify the test suite is covering the right thing by running the test

## Completion Conditions

- [x] Passed by all green TravisCI test
- [x] Get `OK` or `LGTM` from __two__ of rjk